### PR TITLE
Add support for Core adapters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Contributing to Chartboost Mediation iOS Actions
+# Contributing to Chartboost iOS Adapter Actions
 
-Contributions to the Chartboost Mediation iOS Actions repository are not accepted. The repository is provided as-is for usage for usage with the open source Chartboost Mediation Adapter ecosystem.
+Contributions to the Chartboost iOS Adapter Actions repository are not accepted. The repository is provided as-is for usage for usage with the open source Chartboost Mediation Adapter and Chartboost Core Adapter ecosystems.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# Chartboost Mediation iOS Actions
-Repository of GitHub Actions for the Chartboost Mediation iOS Adapter ecosystem.
+# Chartboost iOS Adapter Actions
+Repository of GitHub Actions for the Chartboost Mediation iOS Adapter and Chartboost Core iOS Adapter ecosystems.
+
+All actions accept an optional `CHARTBOOST_PLATFORM` environment variable to indicate the platform to which the adapter belongs.
+
+Supported values are: `Mediation` and `Core`.
+When no value is provided, `Mediation` is assumed.
 
 ## adapter-smoke-test
 
@@ -20,7 +25,7 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-ios-adapter-actions/adapter-smoke-test@v1
         with:
           allow-warnings: true
 ```
@@ -44,7 +49,7 @@ env:
 jobs:
   create-release-branch:
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-ios-adapter-actions/create-adapter-release-branch@v1
         with:
           adapter-version: "4.5.3.0.0"
           partner-version: "~> 5.3.0"
@@ -77,5 +82,5 @@ env:
 jobs:
   release-adapter:
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-ios-adapter-actions/release-adapter@v1
 ``` 

--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -5,11 +5,35 @@ PODSPEC_VERSION_REGEX = /^(\s*spec\.version\s*=\s*')([0-9]+(?>\.[0-9]+){4,5})('\
 PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
 PODSPEC_PARTNER_REGEX = /spec\.dependency\s*'([^']+)'/
 CHANGELOG_PATH = "CHANGELOG.md"
-ADAPTER_CLASS_PREFIX = "ChartboostMediationAdapter"
-ADAPTER_CLASS_VERSION_REGEX = /^(\s*let adapterVersion\s*=\s*")([^"]+)(".*)$/
+ADAPTER_CLASS_PREFIX_MEDIATION = "ChartboostMediationAdapter"
+ADAPTER_CLASS_PREFIX_CORE = "ChartboostCoreConsentAdapter"
+ADAPTER_CLASS_VERSION_REGEX_MEDIATION = /^(\s*let adapterVersion\s*=\s*")([^"]+)(".*)$/
+ADAPTER_CLASS_VERSION_REGEX_CORE = /^(\s*(?>public)?\s*let moduleVersion\s*=\s*")([^"]+)(".*)$/
 SOURCE_DIR_PATH = "./Source"
 SOURCE_FILE_EXTENSIONS = ['.h', '.m', '.swift']
 SOURCE_FILE_COPYRIGHT_NOTICE = "// Copyright 2022-#{Time.now.year} Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
+
+# Returns a platform-specific ADAPTER_CLASS_PREFIX constant.
+def ADAPTER_CLASS_PREFIX
+  platform = ENV['CHARTBOOST_PLATFORM']
+  if platform == 'Core'
+    return ADAPTER_CLASS_PREFIX_CORE
+  else
+    # fallback to 'Mediation'
+    return ADAPTER_CLASS_PREFIX_MEDIATION
+  end
+end
+
+# Returns a platform-specific ADAPTER_CLASS_VERSION_REGEX constant.
+def ADAPTER_CLASS_VERSION_REGEX
+  platform = ENV['CHARTBOOST_PLATFORM']
+  if platform == 'Core'
+    return ADAPTER_CLASS_VERSION_REGEX_CORE
+  else
+    # fallback to 'Mediation'
+    return ADAPTER_CLASS_VERSION_REGEX_MEDIATION
+  end
+end
 
 ###########
 # PODSPEC #


### PR DESCRIPTION
Update documentation, and have some constants depend on the platform (Mediation or Core) as defined by an environment variable.
Core adapters will define that env variable in their workflow before running the action.