### PR TITLE
HB-6315: update copyright header scripts for the year numbers

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -13,7 +13,15 @@ ADAPTER_CLASS_VERSION_REGEX_MEDIATION = /^(\s*let adapterVersion\s*=\s*")([^"]+)
 ADAPTER_CLASS_VERSION_REGEX_CORE = /^(\s*(?>public)?\s*let moduleVersion\s*=\s*")([^"]+)(".*)$/
 SOURCE_DIR_PATH = "./Source"
 SOURCE_FILE_EXTENSIONS = ['.h', '.m', '.swift']
-SOURCE_FILE_COPYRIGHT_NOTICE = "// Copyright 2022-#{Time.now.year} Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
+
+SOURCE_FILE_COPYRIGHT_NOTICE_PART_1_OF_2_CURRENT_YEAR_ONLY = "// Copyright #{Time.now.year} Chartboost, Inc.\n"
+SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2 = "//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
+SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX = 17 # the "-" character between the FROM year and the TO year
+
+SOURCE_FILE_COPYRIGHT_NOTICE_FROM_CURRENT_YEAR_ONLY_REGEX = /#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_1_OF_2_CURRENT_YEAR_ONLY}#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
+SOURCE_FILE_COPYRIGHT_NOTICE_FROM_YEAR_ONLY_REGEX = /\/\/ Copyright 20[0-9][0-9] Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
+SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX = /\/\/ Copyright 20[0-9][0-9]-#{Time.now.year} Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
+SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_TO_YEARS_REGEX = /\/\/ Copyright 20[0-9][0-9]-20[0-9][0-9] Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
 
 # Returns a platform-specific ADAPTER_CLASS_PREFIX constant.
 def ADAPTER_CLASS_PREFIX

--- a/scripts/adapters/update-copyright-headers.rb
+++ b/scripts/adapters/update-copyright-headers.rb
@@ -11,17 +11,52 @@ modified_files = []
 # Iterate over all the files in the source directory
 for_all_source_files do |file_path, contents|
   # Skip if file already has the copyright header
-  if contents.start_with?(SOURCE_FILE_COPYRIGHT_NOTICE)
+  if contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_CURRENT_YEAR_ONLY_REGEX)
+    # No op if the copyright year is the CURRENT year
     next
+  elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX)
+    # No op if the copyright year is from 20XX to the CURRENT year
+    next
+  elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_YEAR_ONLY_REGEX)
+    # The file starts with copyright header that contains outdated FROM year
+    tmp = Tempfile.new("tmp")
+    begin
+      currentYearStartIndex = SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX + 1
+      contents.insert(SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX, "-#{Time.now.year}") # add the current year
+      tmp.puts contents
+
+      # Replace the original file with the new one
+      FileUtils.mv(tmp.path, file_path)
+      modified_files.append(file_path)
+    ensure
+      tmp.close
+      tmp.unlink
+    end
+  elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_TO_YEARS_REGEX)
+    # The file starts with copyright header that contains outdated TO year
+    tmp = Tempfile.new("tmp")
+    begin
+      currentYearStartIndex = SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX + 1
+      contents[currentYearStartIndex..currentYearStartIndex+3] = "#{Time.now.year}" # replace the outdated TO year with the current year
+      tmp.puts contents
+
+      # Replace the original file with the new one
+      FileUtils.mv(tmp.path, file_path)
+      modified_files.append(file_path)
+    ensure
+      tmp.close
+      tmp.unlink
+    end
   else
+    # The file does not start with the copyright header
     tmp = Tempfile.new("tmp")
     begin
       if contents.start_with?("//")
-          # If the file starts with a comment block, replace it with the copyright header
-          tmp.puts contents.sub(COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX, SOURCE_FILE_COPYRIGHT_NOTICE)
+        # If the file starts with a comment block, replace it with the copyright header assuming this file is created this year
+        tmp.puts contents.sub(COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX, SOURCE_FILE_COPYRIGHT_NOTICE_PART_1_OF_2_CURRENT_YEAR_ONLY + SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2)
       else
-          # If there's no comment at the top just insert the copyright header
-          tmp.puts SOURCE_FILE_COPYRIGHT_NOTICE + contents
+        # If there's no comment at the top just insert the copyright header
+        tmp.puts SOURCE_FILE_COPYRIGHT_NOTICE + contents
       end
 
       # Replace the original file with the new one

--- a/scripts/adapters/validate-copyright-headers.rb
+++ b/scripts/adapters/validate-copyright-headers.rb
@@ -5,5 +5,8 @@ require_relative 'common'
 # Iterate over all the files in the source directory
 for_all_source_files do |file_path, contents|
   # Fail some file does not start with the copyright notice
-  abort "Validation failed: #{file_path} does not have a proper copyright notice header." unless contents.start_with?(SOURCE_FILE_COPYRIGHT_NOTICE)
+  abort "Validation failed: #{file_path} does not have a proper copyright notice header." unless (
+    contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_CURRENT_YEAR_ONLY_REGEX) ||
+    contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX)
+  )
 end


### PR DESCRIPTION
Existing script hardcodes 2022 as the starting year, which is not true for the Core SDK and files created in the future.

This PR enables both {current year} and {various starting year}-{current year} copyright header.

This PR is tested by the following Ruby code, which has the same `SOURCE_FILE_COPYRIGHT_NOTICE_...` constant set and the same `if/elsif/else` conditions. Uncomment the `contents =` lines to test all 5 checks in this PR.

```
COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX = /^(?:(?>\/\/[^\n]*\n)+(?>\n?))/
SOURCE_FILE_COPYRIGHT_NOTICE_PART_1_OF_2_CURRENT_YEAR_ONLY = "// Copyright #{Time.now.year} Chartboost, Inc.\n"
SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2 = "//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX = 17

SOURCE_FILE_COPYRIGHT_NOTICE_CURRENT_YEAR_ONLY_REGEX = /#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_1_OF_2_CURRENT_YEAR_ONLY}#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
SOURCE_FILE_COPYRIGHT_NOTICE_FROM_YEAR_ONLY_REGEX = /\/\/ Copyright 20[0-9][0-9] Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX = /\/\/ Copyright 20[0-9][0-9]-#{Time.now.year} Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/
SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_TO_YEARS_REGEX = /\/\/ Copyright 20[0-9][0-9]-20[0-9][0-9] Chartboost, Inc.\n#{SOURCE_FILE_COPYRIGHT_NOTICE_PART_2_OF_2}/

## Uncomment the following `contents` to test different cases
contents = "// Copyright 2023 Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\nThis is case 1"
# contents = "// Copyright 2022-2023 Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\nThis is case 2"
# contents = "// Copyright 2022 Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\nThis is case 3"
# contents = "// Copyright 2021-2022 Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\nThis is case 4"
# contents = "// No copyright info. This is case 5"

# for business logic in update-copyright-headers.rb 
if contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_CURRENT_YEAR_ONLY_REGEX)
    puts "1. Match found: CURRENT year"
    puts contents
elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX)
    puts "2. Match found: FROM year + CURRENT year"
    puts contents
elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_YEAR_ONLY_REGEX)
    currentYearStartIndex = SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX + 1
    puts "3. Match found: outdated FROM year #{contents[currentYearStartIndex..currentYearStartIndex+3]}"
    contents.insert(SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX, "-#{Time.now.year}")
    puts contents
    puts "(updated)"
elsif contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_TO_YEARS_REGEX)
    currentYearStartIndex = SOURCE_FILE_COPYRIGHT_NOTICE_TIME_SPAN_DASH_INDEX + 1
    puts "4. Match found: FROM year + outdated TO year #{contents[currentYearStartIndex..currentYearStartIndex+3]}"
    contents[currentYearStartIndex..currentYearStartIndex+3] = "#{Time.now.year}"
    puts contents
    puts "(updated)"
else
    puts "5. Match not found: add copyright info"
    puts contents
end

# for business logic in validate-copyright-headers.rb abort "Copyright year outdated" unless (
    contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_CURRENT_YEAR_ONLY_REGEX) ||
    contents.match(SOURCE_FILE_COPYRIGHT_NOTICE_FROM_AND_CURRENT_YEARS_REGEX)
)

puts "The copyright heaer is correct"
```