### PR TITLE
Skip backward compatibility check for 0.x series

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -113,6 +113,20 @@ def podspec_partner_sdk_name
   return partner_sdk
 end
 
+# Returns the version of the Chartboost SDK dependency in the podspec.
+def podspec_cb_sdk_version
+  # Obtain the podspec
+  text = read_podspec()
+
+  # Obtain the Chartboost SDK version from the podspec
+  match = text.match(PODSPEC_CB_SDK_REGEX())
+  fail unless !match.nil?
+  sdk_version = match[2]
+
+  # Return value
+  return sdk_version
+end
+
 #############
 # CHANGELOG #
 #############

--- a/scripts/adapters/validate-backward-compatibility.rb
+++ b/scripts/adapters/validate-backward-compatibility.rb
@@ -6,7 +6,13 @@ require_relative 'common'
 abort "Missing argument. Requires: allow-warnings." unless ARGV.count == 1
 allow_warnings = ARGV[0]
 
-# 2. Fix the CB SDK version in the podspec to the lowest one compatible with the adapter.
+# 2. Skip if the CB SDK major version digit is 0.
+# Retrocompatibility is not required for 0.x versions.
+if podspec_cb_sdk_version().start_with?("0.")
+  exit
+end
+
+# 3. Fix the CB SDK version in the podspec to the lowest one compatible with the adapter.
 # Read the podspec file
 podspec = read_podspec()
 # Remove the "~>" in the podspec, keeping everything else the same (capture groups 1 and 2).
@@ -16,11 +22,11 @@ podspec = podspec.sub(PODSPEC_CB_SDK_REGEX(), "\\1\\2")
 # Write the changes
 write_podspec(podspec)
 
-# 3. Validate the podspec, optionally allowing warnings.
+# 4. Validate the podspec, optionally allowing warnings.
 success = system("pod lib lint --verbose #{allow_warnings == 'true' ? '--allow-warnings' : ''}")
 
-# 4. Discard changes made to the podspec file
+# 5. Discard changes made to the podspec file
 `git restore #{podspec_file_path}`
 
-# 5. Fail if podspec validation failed
+# 6. Fail if podspec validation failed
 abort "Backward compatibility validation failed." unless success


### PR DESCRIPTION
Fixes issues with Core adapters that are no longer compatible with Core 0.1.0 or 0.2.0.
Retrocompatibility should not be expected for the 0.x series, since breaking changes might be introduced on any of the minor versions.