### PR TITLE
Use year of first commit as initial year in copyright notice.

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -13,7 +13,6 @@ ADAPTER_CLASS_VERSION_REGEX_MEDIATION = /^(\s*let adapterVersion\s*=\s*")([^"]+)
 ADAPTER_CLASS_VERSION_REGEX_CORE = /^(\s*(?>public)?\s*let moduleVersion\s*=\s*")([^"]+)(".*)$/
 SOURCE_DIR_PATH = "./Source"
 SOURCE_FILE_EXTENSIONS = ['.h', '.m', '.swift']
-SOURCE_FILE_COPYRIGHT_NOTICE = "// Copyright 2022-#{Time.now.year} Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
 
 # Returns a platform-specific ADAPTER_CLASS_PREFIX constant.
 def ADAPTER_CLASS_PREFIX
@@ -46,6 +45,10 @@ def PODSPEC_CB_SDK_REGEX
     # fallback to 'Mediation'
     return PODSPEC_CB_SDK_REGEX_MEDIATION
   end
+end
+
+def SOURCE_FILE_COPYRIGHT_NOTICE
+  "// Copyright #{year_of_first_remote_commit}-#{Time.now.year} Chartboost, Inc.\n//\n// Use of this source code is governed by an MIT-style\n// license that can be found in the LICENSE file.\n\n"
 end
 
 ###########
@@ -209,4 +212,20 @@ def for_all_source_files()
       yield(file_path, contents)
     end
   end
+end
+
+#######
+# GIT #
+#######
+
+# Obtains the year of the first commit in the remote.
+def year_of_first_remote_commit
+  # Fetch from the remote repository silently
+  `git fetch -q origin main 2>/dev/null`
+
+  # Extract the commit year from the oldest commit
+  commit_year = `git log origin/main --reverse --format=%cd --date=format:%Y | head -1`.strip
+
+  # Return the value
+  commit_year
 end

--- a/scripts/adapters/update-copyright-headers.rb
+++ b/scripts/adapters/update-copyright-headers.rb
@@ -4,24 +4,28 @@ require_relative 'common'
 require 'tempfile'
 
 COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX = /^(?:(?>\/\/[^\n]*\n)+(?>\n?))/
+EMPTY_LINES_AT_BEGINNING_OF_FILE_REGEX = /\A(\n|\s)*/
 
 # Keep a list of modified files to output at the end
 modified_files = []
 
+copyright_notice = SOURCE_FILE_COPYRIGHT_NOTICE()
+
 # Iterate over all the files in the source directory
 for_all_source_files do |file_path, contents|
   # Skip if file already has the copyright header
-  if contents.start_with?(SOURCE_FILE_COPYRIGHT_NOTICE)
+  if contents.start_with?(copyright_notice)
     next
   else
     tmp = Tempfile.new("tmp")
     begin
       if contents.start_with?("//")
           # If the file starts with a comment block, replace it with the copyright header
-          tmp.puts contents.sub(COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX, SOURCE_FILE_COPYRIGHT_NOTICE)
+          tmp.puts contents.sub(COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX, copyright_notice)
       else
-          # If there's no comment at the top just insert the copyright header
-          tmp.puts SOURCE_FILE_COPYRIGHT_NOTICE + contents
+          # If there's no comment at the top just insert the copyright header,
+          # removing all the extra empty lines at the beginning of the file first.
+          tmp.puts copyright_notice + contents.sub(EMPTY_LINES_AT_BEGINNING_OF_FILE_REGEX, "")
       end
 
       # Replace the original file with the new one

--- a/scripts/adapters/validate-copyright-headers.rb
+++ b/scripts/adapters/validate-copyright-headers.rb
@@ -2,8 +2,10 @@
 
 require_relative 'common'
 
+copyright_notice = SOURCE_FILE_COPYRIGHT_NOTICE()
+
 # Iterate over all the files in the source directory
 for_all_source_files do |file_path, contents|
   # Fail some file does not start with the copyright notice
-  abort "Validation failed: #{file_path} does not have a proper copyright notice header." unless contents.start_with?(SOURCE_FILE_COPYRIGHT_NOTICE)
+  abort "Validation failed: #{file_path} does not have a proper copyright notice header." unless contents.start_with?(copyright_notice)
 end


### PR DESCRIPTION
I also improved the copyright header replacement script using the latest logic in our fastlane scripts, where we also remove any extra new lines between the header and the first text in the file.