### PR TITLE
Improve feedback when copyright header validation fails

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -1,5 +1,6 @@
 # Common definitions used by other scripts.
 
+COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX = /\A(?:(?>\/\/[^\n]*\n)+(?>\n?))/
 PODSPEC_CB_SDK_REGEX_CORE = /(spec\.dependency\s*'ChartboostCoreSDK',\s*')\~>\s*(\d+\.\d+(\.\d+)?')/
 PODSPEC_CB_SDK_REGEX_MEDIATION = /(spec\.dependency\s*'ChartboostMediationSDK',\s*')\~>\s*(\d+\.\d+(\.\d+)?')/
 PODSPEC_PATH_PATTERN = "*.podspec"

--- a/scripts/adapters/update-copyright-headers.rb
+++ b/scripts/adapters/update-copyright-headers.rb
@@ -3,7 +3,6 @@
 require_relative 'common'
 require 'tempfile'
 
-COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX = /^(?:(?>\/\/[^\n]*\n)+(?>\n?))/
 EMPTY_LINES_AT_BEGINNING_OF_FILE_REGEX = /\A(\n|\s)*/
 
 # Keep a list of modified files to output at the end

--- a/scripts/adapters/validate-copyright-headers.rb
+++ b/scripts/adapters/validate-copyright-headers.rb
@@ -7,5 +7,13 @@ copyright_notice = SOURCE_FILE_COPYRIGHT_NOTICE()
 # Iterate over all the files in the source directory
 for_all_source_files do |file_path, contents|
   # Fail some file does not start with the copyright notice
-  abort "Validation failed: #{file_path} does not have a proper copyright notice header." unless contents.start_with?(copyright_notice)
+  unless contents.start_with?(copyright_notice)
+    current_header_match = contents.match(COMMENT_BLOCK_AT_BEGINNING_OF_FILE_REGEX)
+    if current_header_match
+      current_header = "Found:\n#{current_header_match.to_s}"
+    else
+      current_header = "First line:\n#{contents.lines.first}"
+    end
+    abort "Validation failed: #{file_path} does not have a proper copyright notice header.\nExpected:\n#{copyright_notice}#{current_header}"
+  end
 end


### PR DESCRIPTION
This will help debug the failures we are getting: https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads/actions/runs/6511614734/job/17687644612?pr=44