### PR TITLE
Fix year of first commit script

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -221,6 +221,8 @@ end
 
 # Obtains the year of the first commit in the remote.
 def year_of_first_remote_commit
+    `git remote get-url origin`
+    
   # Fetch from the remote repository silently
   `git fetch -q origin main 2>/dev/null`
 

--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -221,8 +221,9 @@ end
 
 # Obtains the year of the first commit in the remote.
 def year_of_first_remote_commit
-    `git remote get-url origin`
-    
+    puts "remote:"
+   puts `git remote get-url origin`
+
   # Fetch from the remote repository silently
   `git fetch -q origin main 2>/dev/null`
 

--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -221,11 +221,10 @@ end
 
 # Obtains the year of the first commit in the remote.
 def year_of_first_remote_commit
-    puts "remote:"
-   puts `git remote get-url origin`
-
   # Fetch from the remote repository silently
-  `git fetch -q origin main 2>/dev/null`
+  # --unshallow is needed to make sure we fetch all the commits, since the repo may have been
+  # cloned with a limited depth (shallow clone)
+  `git fetch --unshallow -q origin main 2>/dev/null`
 
   # Extract the commit year from the oldest commit
   commit_year = `git log origin/main --reverse --format=%cd --date=format:%Y | head -1`.strip


### PR DESCRIPTION
Fixes issue where copyright validation checks fail for adapter PRs. https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads/actions/runs/6511614734/job/17689775222?pr=44

The proper date was not being pulled due to fetch not actually fetching all the commits in the repo by default.