### PR TITLE
HB-5880: Add step to validate CHANGELOG entry before releasing

### DIFF
--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -25,6 +25,11 @@ runs:
       run: echo "version=$(ruby ${{ github.action_path }}/../scripts/adapters/adapter-version.rb)" >> $GITHUB_OUTPUT
       shell: bash
 
+    # Validate release.
+    - name: Validate Release
+      run: ruby "${{ github.action_path }}/../scripts/adapters/validate-release.rb ${{ steps.release_version.outputs.version }}"
+      shell: bash
+
     # Push the release tag.
     - name: Tag
       run: git tag ${{ steps.release_version.outputs.version }} && git push origin ${{ steps.release_version.outputs.version }}

--- a/scripts/adapters/validate-release.rb
+++ b/scripts/adapters/validate-release.rb
@@ -1,0 +1,12 @@
+# Runs validations before releasing a new version of an adapter.
+
+require_relative 'common'
+
+# Parse the version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+version = ARGV[0]
+
+# Validate that the changelog contains an entry for the version to be released.
+changelog = read_changelog
+regex = /^### #{version}$/m
+abort "Release validation failed: entry for #{version} not found in the CHANGELOG." unless changelog.match?(regex)


### PR DESCRIPTION
* This was unlikely to happen to us since we automatically add the `CHANGELOG` entry when creating the release branch, but it was simple enough to do and doesn't hurt to have. 
* I tested locally by running the script from an adapter directory, and testing against an entry that exists, and an entry that doesn't.