### PR TITLE
Run smoke tests before release

### DIFF
--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -27,6 +27,11 @@ runs:
       run: ruby "${{ github.action_path }}/../scripts/adapters/validate-copyright-headers.rb"
       shell: bash
 
+    # Check that the changelog contains an entry for the adapter version.
+    - name: Validate Changelog
+      run: ruby "${{ github.action_path }}/../scripts/adapters/validate-changelog.rb"
+      shell: bash
+
     # Validate the podspec.
     - name: Validate Podspec
       run: pod lib lint --verbose ${{ inputs.allow-warnings == 'true' && '--allow-warnings' || '' }}

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -19,15 +19,16 @@ runs:
       with:
         token: ${{ env.GITHUB_TOKEN }}
 
+    # Run smoke tests to ensure the changes are valid before making the release.
+    - name: Run Smoke Tests
+      uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      with:
+        allow-warnings: ${{ inputs.allow-warnings }}
+
     # Obtain the new adapter version.
     - name: Obtain Adapter Version
       id: release_version
       run: echo "version=$(ruby ${{ github.action_path }}/../scripts/adapters/adapter-version.rb)" >> $GITHUB_OUTPUT
-      shell: bash
-
-    # Validate release.
-    - name: Validate Release
-      run: ruby "${{ github.action_path }}/../scripts/adapters/validate-release.rb" "${{ steps.release_version.outputs.version }}"
       shell: bash
 
     # Push the release tag.

--- a/scripts/adapters/validate-changelog.rb
+++ b/scripts/adapters/validate-changelog.rb
@@ -1,12 +1,9 @@
-# Runs validations before releasing a new version of an adapter.
+# Validates that a changelog entry exists for the adapter version.
 
 require_relative 'common'
 
-# Parse the version string from the arguments
-abort "Missing argument. Requires: version string." unless ARGV.count == 1
-version = ARGV[0]
-
 # Validate that the changelog contains an entry for the version to be released.
 changelog = read_changelog
+version = podspec_version
 regex = /^### #{version}$/m
 abort "Release validation failed: entry for #{version} not found in the CHANGELOG." unless changelog.match?(regex)


### PR DESCRIPTION
I updated the release workflow to run all the smoke test checks as a first step. This ensures that an adapter is not released by mistake even if the PR didn't pass its checks.

Tested with a test branch on the reference adapter, where I made it so the changelog validation would fail. This issue is picked up both by the smoke tests and the release workflow:
https://github.com/ChartBoost/chartboost-mediation-ios-adapter-reference/actions/runs/6790968966/job/18461538113?pr=49
https://github.com/ChartBoost/chartboost-mediation-ios-adapter-reference/actions/runs/6790977556/job/18461561621