### PR TITLE
Fix release action

### DIFF
--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -16,6 +16,8 @@ runs:
       # Check out the repo.
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        token: ${{ env.GITHUB_TOKEN }}
 
     # Check that the adapter version in the podpsec and in the PartnerAdapter Swift implementation are the same.
     - name: Validate Adapter and Podspec Version Match


### PR DESCRIPTION
We're getting permission errors on release:
<img width="929" alt="Screenshot 2023-11-16 at 9 58 42 AM" src="https://github.com/ChartBoost/chartboost-ios-adapter-actions/assets/9442254/401a834a-0993-42e4-94d6-dfc1abad9515">

This is due to the release action now calling the smoke-test action, which itself checks out the repo but without the GitHub token. This makes all subsequent actions in the release workflow that run git commands to have no GitHub token associated.

Fix by doing checkout with github token on smoke tests too, for cases where it's run from the release action.