### PR TITLE
Update adapter min os version based on partner

### DIFF
--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -72,6 +72,18 @@ runs:
       run: git add ${{ steps.copyright-headers.outputs.files }} && git commit -m "[AUTO-GENERATED] Update copyright headers"
       shell: bash
 
+    # Update min OS version to match partner SDK.
+    - name: Update Min OS Version
+      id: min-os-version
+      run: echo "files=$(ruby ${{ github.action_path }}/../scripts/adapters/update-min-os-version.rb)" "${{ inputs.partner-version }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Commit changes to all source files.
+    - name: Commit Changes
+      if: ${{ steps.min-os-version.outputs.files != '' }}
+      run: git add ${{ steps.min-os-version.outputs.files }} && git commit -m "[AUTO-GENERATED] Update min OS version to match partner"
+      shell: bash
+
     # Push changes.
     - name: Push Changes
       run: git push -u origin "release/${{ inputs.adapter-version }}"

--- a/scripts/adapters/add-changelog-entry.rb
+++ b/scripts/adapters/add-changelog-entry.rb
@@ -18,7 +18,8 @@ partner_sdk_name = podspec_partner_sdk_name()
 changelog = read_changelog()
 
 # Add the new entry right before the last one, if the entry does not already exist for this version
-if !changelog.include? "### #{adapter_version}"
-  changelog = changelog.sub("###", "### #{adapter_version}\n- This version of the adapter has been certified with #{partner_sdk_name} #{partner_version}.\n\n###")
+entry_header = changelog_entry_header(adapter_version)
+if !changelog.include? entry_header
+  changelog = changelog.sub(CHANGELOG_ENTRY_HEADER_PREFIX, "#{entry_header}\n- This version of the adapter has been certified with #{partner_sdk_name} #{partner_version}.\n\n###")
   write_changelog(changelog)
 end

--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -9,6 +9,7 @@ PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
 PODSPEC_MIN_OS_VERSION_REGEX = /^(\s*spec\.ios\.deployment_target\s*=\s*')([0-9]+(?>\.[0-9]+){0,2})('\s*)$/
 PODSPEC_PARTNER_REGEX = /spec\.dependency\s*'([^']+)'/
 CHANGELOG_PATH = "CHANGELOG.md"
+CHANGELOG_ENTRY_HEADER_PREFIX = "###"
 ADAPTER_CLASS_PREFIX_MEDIATION = "ChartboostMediationAdapter"
 ADAPTER_CLASS_PREFIX_CORE = "ChartboostCoreConsentAdapter"
 ADAPTER_CLASS_VERSION_REGEX_MEDIATION = /^(\s*let adapterVersion\s*=\s*")([^"]+)(".*)$/
@@ -165,6 +166,11 @@ end
 # Writes a string to the changelog file.
 def write_changelog(text)
   File.open(CHANGELOG_PATH, "w") { |file| file.puts text }
+end
+
+# Returns the changelog entry header line for a specific version.
+def changelog_entry_header(version)
+  "#{CHANGELOG_ENTRY_HEADER_PREFIX} #{version}"
 end
 
 #################

--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -6,12 +6,15 @@ PODSPEC_CB_SDK_REGEX_MEDIATION = /(spec\.dependency\s*'ChartboostMediationSDK',\
 PODSPEC_PATH_PATTERN = "*.podspec"
 PODSPEC_VERSION_REGEX = /^(\s*spec\.version\s*=\s*')([0-9]+(?>\.[0-9]+){4,5})('\s*)$/
 PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
+PODSPEC_MIN_OS_VERSION_REGEX = /^(\s*spec\.ios\.deployment_target\s*=\s*')([0-9]+(?>\.[0-9]+){0,2})('\s*)$/
 PODSPEC_PARTNER_REGEX = /spec\.dependency\s*'([^']+)'/
 CHANGELOG_PATH = "CHANGELOG.md"
 ADAPTER_CLASS_PREFIX_MEDIATION = "ChartboostMediationAdapter"
 ADAPTER_CLASS_PREFIX_CORE = "ChartboostCoreConsentAdapter"
 ADAPTER_CLASS_VERSION_REGEX_MEDIATION = /^(\s*let adapterVersion\s*=\s*")([^"]+)(".*)$/
 ADAPTER_CLASS_VERSION_REGEX_CORE = /^(\s*(?>public)?\s*let moduleVersion\s*=\s*")([^"]+)(".*)$/
+README_PATH = "README.md"
+README_MIN_OS_VERSION_REGEX = /^(\s*\|\s*iOS\s*\|\s*)([0-9]+(?>\.[0-9]+){0,2})(\+?\s*\|\s*)$/
 SOURCE_DIR_PATH = "./Source"
 SOURCE_FILE_EXTENSIONS = ['.h', '.m', '.swift']
 
@@ -89,6 +92,20 @@ def podspec_version
 
   # Return value
   version
+end
+
+# Returns the podspec min OS version value.
+def podspec_min_os_version
+  # Obtain the podspec
+  text = read_podspec()
+
+  # Obtain the min OS version from the podspec
+  match = text.match(PODSPEC_MIN_OS_VERSION_REGEX)
+  fail unless !match.nil?
+  version = match[2]
+
+  # Return value
+  return version
 end
 
 # Returns the podspec version value.
@@ -193,6 +210,30 @@ def adapter_class_version
 
   # Return value
   version
+end
+
+##########
+# README #
+##########
+
+# Returns the readme file contents as a string.
+def read_readme
+  # Read the contents
+  text = File.read(readme_file_path)
+  fail unless !text.nil?
+
+  # Return value
+  text
+end
+
+# Writes a string to the readme file.
+def write_readme(text)
+  File.open(readme_file_path, "w") { |file| file.puts text }
+end
+
+# The path to the readme file.
+def readme_file_path
+  README_PATH
 end
 
 ################

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -44,6 +44,15 @@ if partner_min_os_version != current_adapter_version
   # Write the changes
   write_readme(readme)
   modified_files.append(readme_file_path)
+
+  # Read the changelog file
+  changelog = read_changelog()
+  # Add a note to the corresponding entry
+  entry_header = changelog_entry_header(podspec_version)
+  changelog = changelog.sub(entry_header, "#{entry_header}\n- The minimum OS version required is now iOS #{partner_min_os_version}.")
+  # Write the changes
+  write_changelog(changelog)
+  modified_files.append(CHANGELOG_PATH)
 end
 
 # Output the list of modified files

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -1,0 +1,50 @@
+# Updates the adapter minimum OS version based on the partner SDK minimum.
+
+require_relative 'common'
+require 'json'
+
+# Function to obtain the min OS version info from the partner podspec
+def min_os_version(pod_name, pod_version)
+  # Use the `pod spec cat` command to get the podspec as JSON
+  podspec_json = `pod spec cat #{pod_name} --version=#{pod_version}`
+  podspec = JSON.parse(podspec_json)
+  
+  # Extract the platform information; assuming iOS here
+  min_os_version = podspec['platforms']['ios']
+  
+  # Return the version string
+  min_os_version
+end
+
+# Parse the partner version string from the arguments
+abort "Missing argument. Requires: partner version." unless ARGV.count == 1
+partner_version = ARGV[0]
+
+# Obtain the min OS versions for the current adapter and the desired partner version
+partner_min_os_version = min_os_version(podspec_partner_sdk_name(), partner_version)
+current_adapter_version = podspec_min_os_version()
+
+# Keep a list of modified files to output at the end
+modified_files = []
+
+# Update adapter files with the new min OS version based on the partner if it's different from the current one.
+if partner_min_os_version != current_adapter_version
+  # Read the podspec file
+  podspec = read_podspec()
+  # Replace the min OS version string (capture group 2), keeping everything else the same (capture groups 1 and 3)
+  podspec = podspec.sub(PODSPEC_MIN_OS_VERSION_REGEX, "\\1#{partner_min_os_version}\\3")
+  # Write the changes
+  write_podspec(podspec)
+  modified_files.append(podspec_file_path)
+
+  # Read the readme file
+  readme = read_readme()
+  # Replace the min OS version string (capture group 2), keeping everything else the same (capture groups 1 and 3)
+  readme = readme.sub(README_MIN_OS_VERSION_REGEX, "\\1#{partner_min_os_version}\\3")
+  # Write the changes
+  write_readme(readme)
+  modified_files.append(readme_file_path)
+end
+
+# Output the list of modified files
+puts modified_files.join(' ')


### PR DESCRIPTION
Update the `create-adapter-release-branch` action so it identifies if the new partner SDK version has bumped the min supported iOS version and updates the adapter's own min OS version to match the new value.