### PR TITLE
Fix create release branch workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "cocoapods"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source "https://rubygems.org"
-
-gem "cocoapods"

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -20,6 +20,14 @@ runs:
     - name: Checkout Branch
       uses: actions/checkout@v3
 
+    # Set up Ruby and gems
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+        working-directory: "${{ github.action_path }}/.." # Specify the path to the actions root directory where the Gemfile is
+
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match
       run: ruby "${{ github.action_path }}/../scripts/adapters/validate-adapter-and-partner-versions.rb" "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -20,13 +20,12 @@ runs:
     - name: Checkout Branch
       uses: actions/checkout@v3
 
-    # Set up Ruby and gems
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-        bundler-cache: true
-        working-directory: "${{ github.action_path }}/.." # Specify the path to the actions root directory where the Gemfile is
+    # Install gemfile dependencies
+    - name: Install gemfile dependencies
+      run: bundle install
+      shell: bash
+      env:
+        BUNDLE_GEMFILE: "${{ github.action_path }}/../Gemfile"
 
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -20,13 +20,6 @@ runs:
     - name: Checkout Branch
       uses: actions/checkout@v3
 
-    # Install gemfile dependencies
-    - name: Install gemfile dependencies
-      run: bundle install
-      shell: bash
-      env:
-        BUNDLE_GEMFILE: "${{ github.action_path }}/../Gemfile"
-
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match
       run: ruby "${{ github.action_path }}/../scripts/adapters/validate-adapter-and-partner-versions.rb" "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -75,7 +75,7 @@ runs:
     # Update min OS version to match partner SDK.
     - name: Update Min OS Version
       id: min-os-version
-      run: echo "files=$(ruby ${{ github.action_path }}/../scripts/adapters/update-min-os-version.rb)" "${{ inputs.partner-version }}" >> $GITHUB_OUTPUT
+      run: echo "files=$(ruby ${{ github.action_path }}/../scripts/adapters/update-min-os-version.rb '${{ inputs.partner-version }}')" >> $GITHUB_OUTPUT
       shell: bash
 
     # Commit changes to all source files.

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -6,11 +6,13 @@ require 'json'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  result = `pod repo update`
-  abort("#{result}")
+  `pod repo update`
 
   # Use the `pod spec cat` command to get the podspec as JSON
-  podspec_json = `pod spec cat #{pod_name} --version=#{pod_version}`
+  podspec_json = `pod spec cat #{pod_name} --version=#{pod_version} 2>&1` # 2>&1 captures both stdout and stderr
+  unless $?.success?  # ensures that the previous command succeeded
+    abort "`pod spec cat` failed. Error: #{podspec_json}"
+  end
   begin
     podspec = JSON.parse(podspec_json)
   rescue => error

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -17,6 +17,10 @@ def min_os_version(pod_name, pod_version)
   unless status.success?
     abort "`pod setup` error: #{stdout_str} #{stderr_str}"
   end
+
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'list')
+  abort "`pod repo list` output: #{stdout_str} #{stderr_str}"
+
   stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
   unless status.success?
     abort "`pod repo update` error: #{stdout_str} #{stderr_str}"

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -6,6 +6,12 @@ require 'open3'
 
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
+  # Attempt to add the trunk repo explicitly
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add', 'trunk', 'https://github.com/CocoaPods/Specs.git')
+  unless status.success?
+    puts "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
+  end
+
   # Update the pod repos to ensure the latest info is available
   stdout_str, stderr_str, status = Open3.capture3('pod', 'setup')
   unless status.success?

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -6,16 +6,11 @@ require 'open3'
 
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
+
   # Attempt to add the trunk repo explicitly
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add', 'trunk-adapter-actions', 'https://github.com/CocoaPods/Specs.git', '--verbose')
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add-cdn', 'trunk', 'https://cdn.cocoapods.org')
   unless status.success?
     abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
-  end
-
-  # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'setup')
-  unless status.success?
-    abort "`pod setup` error: #{stdout_str} #{stderr_str}"
   end
 
   stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'list')

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -9,7 +9,7 @@ def min_os_version(pod_name, pod_version)
   # Attempt to add the trunk repo explicitly
   stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add', 'trunk', 'https://github.com/CocoaPods/Specs.git')
   unless status.success?
-    puts "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
+    abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
   end
 
   # Update the pod repos to ensure the latest info is available

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,7 +7,7 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update', 'trunk')
   unless status.success?
     abort "`pod repo update` error: #{stdout_str} #{stderr_str}"
   end

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,9 +7,13 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Attempt to add the trunk repo explicitly
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add', 'trunk-adapter-actions', 'https://github.com/CocoaPods/Specs.git', '--verbose')
+  unless status.success?
+    abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
+  end
 
   # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'update', pod_name)
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'setup')
   unless status.success?
     abort "`pod setup` error: #{stdout_str} #{stderr_str}"
   end

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,7 +7,10 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  `pod repo update`
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
+  unless status.success?
+    abort "`pod repo update` error: #{stdout_str} #{stderr_str}"
+  end
 
   # Use the `pod spec cat` command to get the podspec as JSON
   stdout_str, stderr_str, status = Open3.capture3('pod', 'spec', 'cat', pod_name, "--version=#{pod_version}")

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -42,6 +42,9 @@ end
 abort "Missing argument. Requires: partner version." unless ARGV.count == 1
 partner_version = ARGV[0]
 
+# Sanitize partner version string used to fetch the podspec info
+partner_version = partner_version.delete_prefix('~> ')
+
 # Obtain the min OS versions for the current adapter and the desired partner version
 partner_min_os_version = min_os_version(podspec_partner_sdk_name(), partner_version)
 current_adapter_version = podspec_min_os_version()

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,10 +7,8 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update', 'trunk')
-  unless status.success?
-    abort "`pod repo update` error: #{stdout_str} #{stderr_str}"
-  end
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'list')
+    abort "`pod repo list` output: #{stdout_str} #{stderr_str}"
 
   # Use the `pod spec cat` command to get the podspec as JSON
   stdout_str, stderr_str, status = Open3.capture3('pod', 'spec', 'cat', pod_name, "--version=#{pod_version}")

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -13,9 +13,6 @@ def min_os_version(pod_name, pod_version)
     abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
   end
 
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'list')
-  abort "`pod repo list` output: #{stdout_str} #{stderr_str}"
-
   stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
   unless status.success?
     abort "`pod repo update` error: #{stdout_str} #{stderr_str}"

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,7 +7,11 @@ require 'json'
 def min_os_version(pod_name, pod_version)
   # Use the `pod spec cat` command to get the podspec as JSON
   podspec_json = `pod spec cat #{pod_name} --version=#{pod_version}`
-  podspec = JSON.parse(podspec_json)
+  begin
+    podspec = JSON.parse(podspec_json)
+  rescue => error
+    abort "JSON parsing failed. Error: #{error.message}. Invalid JSON: '#{podspec_json}'"
+  end
   
   # Extract the platform information; assuming iOS here
   min_os_version = podspec['platforms']['ios']

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,17 +7,10 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
 
-  # Attempt to add the trunk repo explicitly
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add-cdn', 'trunk', 'https://cdn.cocoapods.org')
-  unless status.success?
-    abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
-  end
-
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
-  unless status.success?
-    abort "`pod repo update` error: #{stdout_str} #{stderr_str}"
-  end
-
+  # Update cocoapods repos to ensure the local info is up to date
+  `pod repo add-cdn trunk https://cdn.cocoapods.org`
+  `pod repo update`
+  
   # Use the `pod spec cat` command to get the podspec as JSON
   stdout_str, stderr_str, status = Open3.capture3('pod', 'spec', 'cat', pod_name, "--version=#{pod_version}")
   unless status.success?

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,8 +7,14 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'list')
-    abort "`pod repo list` output: #{stdout_str} #{stderr_str}"
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'setup')
+  unless status.success?
+    abort "`pod setup` error: #{stdout_str} #{stderr_str}"
+  end
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'update')
+  unless status.success?
+    abort "`pod repo update` error: #{stdout_str} #{stderr_str}"
+  end
 
   # Use the `pod spec cat` command to get the podspec as JSON
   stdout_str, stderr_str, status = Open3.capture3('pod', 'spec', 'cat', pod_name, "--version=#{pod_version}")

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -6,8 +6,9 @@ require 'json'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Update the pod repos to ensure the latest info is available
-  `pod repo update`
-  
+  result = `pod repo update`
+  abort("#{result}")
+
   # Use the `pod spec cat` command to get the podspec as JSON
   podspec_json = `pod spec cat #{pod_name} --version=#{pod_version}`
   begin

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -7,13 +7,9 @@ require 'open3'
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
   # Attempt to add the trunk repo explicitly
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'repo', 'add', 'trunk', 'https://github.com/CocoaPods/Specs.git')
-  unless status.success?
-    abort "`pod repo add trunk` error: #{stdout_str} #{stderr_str}"
-  end
 
   # Update the pod repos to ensure the latest info is available
-  stdout_str, stderr_str, status = Open3.capture3('pod', 'setup')
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'update', pod_name)
   unless status.success?
     abort "`pod setup` error: #{stdout_str} #{stderr_str}"
   end

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -2,6 +2,7 @@
 
 require_relative 'common'
 require 'json'
+require 'open3'
 
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
@@ -9,10 +10,12 @@ def min_os_version(pod_name, pod_version)
   `pod repo update`
 
   # Use the `pod spec cat` command to get the podspec as JSON
-  podspec_json = `pod spec cat #{pod_name} --version=#{pod_version} 2>&1` # 2>&1 captures both stdout and stderr
-  unless $?.success?  # ensures that the previous command succeeded
-    abort "`pod spec cat` failed. Error: #{podspec_json}"
+  stdout_str, stderr_str, status = Open3.capture3('pod', 'spec', 'cat', pod_name, "--version=#{pod_version}")
+  unless status.success?
+    abort "`pod spec cat` error: #{stdout_str} #{stderr_str}"
   end
+  podspec_json = stdout_str
+
   begin
     podspec = JSON.parse(podspec_json)
   rescue => error

--- a/scripts/adapters/update-min-os-version.rb
+++ b/scripts/adapters/update-min-os-version.rb
@@ -5,6 +5,9 @@ require 'json'
 
 # Function to obtain the min OS version info from the partner podspec
 def min_os_version(pod_name, pod_version)
+  # Update the pod repos to ensure the latest info is available
+  `pod repo update`
+  
   # Use the `pod spec cat` command to get the podspec as JSON
   podspec_json = `pod spec cat #{pod_name} --version=#{pod_version}`
   begin


### PR DESCRIPTION
Fix issues with the last update.
I tested by manually pushing the release tag and running the adapter action on VungleAds.

Changes:
- Syntax fix in GitHub action run step
- Update cocoapods info before doing `pod spec cat`. Note I had to manually add trunk since GitHub runners don't seem to have it preinstalled (I confirmed by running `pod repo list` and getting 0 repos).
- Remove `~> ` prefix from partner version when used in `pod spec cat`.
- Improve error messages for debugging.